### PR TITLE
update system strings

### DIFF
--- a/client/strings/en.conf
+++ b/client/strings/en.conf
@@ -84,10 +84,10 @@
 !system 519 Select an Xyz Material to detach
 !system 520 Select a monster to change control
 !system 521 Select another card to replace the destroyed card(s)
-!system 522 Select a monster which is in face-up Attack Position
-!system 523 Select a monster which is in face-up Defense Position
-!system 524 Select attack monster
-!system 525 Select defense monster
+!system 522 Select a monster in face-up Attack Position
+!system 523 Select a monster in face-up Defense Position
+!system 524 Select a monster in face-down Attack Position
+!system 525 Select a monster in face-down Defense Position
 !system 526 Select a card to reveal
 !system 527 Select a card to place on the field
 !system 528 Select a monster to change


### PR DESCRIPTION
Update for the last few i missed

Some things I noticed about these strings : 
-For spaces they dont use a Whitespace or Tab , they use an invisible character you have to copy and paste to replace the spaces between each word , otherwise the message will get cut off in some English Ygopro systems , atleast if you edit it in Notepad++
-I assume it was from a patch awhile back in the source code that helped make spaces possible that caused it, or maybe Notepad++ is just a bad program to edit it in general , idk..

Thanks to mercury233 for the translations , also found in constant.lua : 
HINTMSG_FACEUPATTACK	=522	--请选择表侧攻击表示的怪兽
HINTMSG_FACEUPDEFENSE	=523	--请选择表侧守备表示的怪兽
HINTMSG_FACEDOWNATTACK	=524	--请选择里侧攻击表示的怪兽
HINTMSG_FACEDOWNDEFENSE	=525	--请选择里侧守备表示的怪兽