### PR TITLE
update strings.conf

### DIFF
--- a/http/strings/en.conf
+++ b/http/strings/en.conf
@@ -1,7 +1,7 @@
 #The first line is used for comment
 #line doesn't start with '!' is also neglected
 #system
-!system 1 Normal Summon
+!system 1 Normal Summon or Set
 !system 2 Special Summon
 !system 3 Flip Summon
 !system 4 Normal Summoned
@@ -56,7 +56,7 @@
 !system 207 Revealing %d card(s):
 !system 208 Confirm %d card(s):
 !system 209 The card has met the requisites
-!system 210 Select if you want continue:
+!system 210 Continue selecting cards?
 !system 211 Round count:
 !system 212 Declared card:
 !system 213 Declared type:
@@ -73,9 +73,9 @@
 !system 508 Select a card to Normal Summon
 !system 509 Select a card to Special Summon
 !system 510 Select a card to Set on the field
-!system 511 Select a monster to use as Fusion Material
-!system 512 Select a monster to use as Synchro Material
-!system 513 Select a monster to be Xyz Material
+!system 511 Select a card to use as Fusion Material
+!system 512 Select a card to use as Synchro Material
+!system 513 Select a card to be Xyz Material
 !system 514 Select a face-up card on the field
 !system 515 Select a face-down card on the field
 !system 516 Select a monster in Attack Position
@@ -90,7 +90,7 @@
 !system 525 Select a monster in face-down Defense Position
 !system 526 Select a card to reveal
 !system 527 Select a card to place on the field
-!system 528 Select a monster to change
+!system 528 Select a monster to change its battle position
 !system 529 Select your card
 !system 530 Select your opponent's card
 !system 531 Select the highest-Level monsters for Tribute
@@ -100,7 +100,7 @@
 !system 551 Select a target for the effect
 !system 552 Call Head or Tails
 !system 553 Choose 1 die result
-!system 554 Select a category
+!system 554 Declare 1 card type
 !system 555 Select an option
 !system 556 Select effect to activate/resolve
 !system 560 Select
@@ -161,7 +161,7 @@
 !system 1055 Effect
 !system 1056 Fusion
 !system 1057 Ritual
-!system 1058 Trap Monsters
+!system 1058 Trap Monster
 !system 1059 Spirit
 !system 1060 Union
 !system 1061 Gemini
@@ -202,7 +202,7 @@
 !system 1119 Token
 !system 1120 Type-Related
 !system 1121 Attribute-Related
-!system 1122 Reduce LP
+!system 1122 Decrease LP
 !system 1123 Increase LP
 !system 1124 Cannot Destroy
 !system 1125 Cannot Target
@@ -339,7 +339,7 @@
 !system 1351 Surrender
 !system 1352 Main message：
 !system 1353 Start at turn：
-!system 1354 Hide Set Names 
+!system 1354 Hide Archetype Names 
 !system 1355 Hide Chain Buttons
 !system 1360 Previous
 !system 1370 Level↑
@@ -370,7 +370,7 @@
 !system 1512 Choice of opponent:[%d]
 !system 1600 Card position changed
 !system 1601 A card is Set
-!system 1602 Change a card
+!system 1602 Card control is changed
 !system 1603 [%ls]Normal Summon...
 !system 1604 Normal Summon success
 !system 1605 [%ls]Special Summon...
@@ -381,8 +381,8 @@
 !system 1610 [%ls](%ls,%d)targeted
 !system 1611 You drew %d card(s)
 !system 1612 Your opponent drew %d card(s)
-!system 1613 You received %d damage
-!system 1614 Your opponent received %d damage
+!system 1613 You lost %d LP
+!system 1614 Your opponent lost %d LP
 !system 1615 You gained %d LP
 !system 1616 Your opponent gained %d LP
 !system 1617 [%ls] has placed %d [%ls]
@@ -410,7 +410,7 @@
 !system 2046 Enable sound effects
 !system 2047 Enable music
 #tips
-!system 1700 You can right mouse button [%ls]
+!system 1700 You can also right-click to [%ls]
 #victory reason
 !victory 0x0 Surrendered
 !victory 0x1 LP reached 0
@@ -511,7 +511,7 @@
 !setname 0xb Infernity
 !setname 0xc Alien
 !setname 0xd Saber
-!setname 0x100d X－Saber
+!setname 0x100d X-Saber
 !setname 0xe Watt
 !setname 0xf Ojama
 !setname 0x10 Gusto
@@ -559,10 +559,10 @@
 !setname 0x1034 Crystal Beast
 !setname 0x2034 Rainbow
 !setname 0x93 Cyber
-!setname 0x94 Cybernetic
 !setname 0x1093 Cyber Dragon
 !setname 0x2093 Cyber Angel
 !setname 0x103 Cyber Dragon Related
+!setname 0x94 Cybernetic
 !setname 0x35 Fabled
 !setname 0x1035 The Fabled
 !setname 0x36 Machina


### PR DESCRIPTION
## A few more small errors i noticed while playing.. ##
I forgot to copy the character between the words last time and used a white space instead , thats why some strings were cut off , but that shouldnt be a problem this time : 
- `!system 1 Normal Summon or Set`
If i choose to Normal Set *Fusilier Dragon, the Dual-Mode Beast* and any monster with "You can Normal Summon/Set this card without Tributing" , im giving an option for this string , and if i want to Set it normally , it shouldnt just say "Normal Summon" , it should include "Set" too
- `!system 210 Continue selecting cards?`
When i played *Tuningware* , i noticed the Yes/No string was wrong
[Source](https://github.com/Fluorohydride/ygopro/blob/master/strings.conf#L61)
- `!system 511 Select a card to use as Fusion Material`
- `!system 512 Select a card to use as Synchro Material`
- `!system 513 Select a card to be Xyz Material`
This is for a rare illegal card [Yasushi the Skull Knight](http://yugioh.wikia.com/wiki/Yasushi_the_Skull_Knight) , and that manga card that uses cards in the pendulum zones as materials , and also as a pre-caution for future effects , in case some effects will use non-monsters as materials too
- `!system 554 Declare 1 card type`
On *SPYRAL Super Agent* i noticed this
Source : `HINTMSG_CARDTYPE		=554	--请选择一个种类`
Also "Category" may be confused with Effect Categories , like "Search" , "To Grave" , etc.
- `!system 1354 Hide Archetype Names `
To keep consistent with `!system 1329 Archetype: ` & `!system 1393 Archetype:`
And "Set" may be confused with "Booster Sets"
- `!system 1613 You lost %d LP`
- `!system 1614 Your opponent lost %d LP`
If an effect causes my LP to **halve** or i **lose** LP instead of taking damage , this string will represent those effects too
- `!system 1700 You can also right-click to [%ls]`
In my opinion this string makes more sense , as you can see its application here :
![Image1](http://i.imgur.com/ipgLGqX.png)
#
**Some small tweaks :**
- `!system 1058 Trap Monster`
To keep consistent with the singular "Reptile" , "Tuner", "Pendulum", etc.
- `!system 1122 Decrease LP`
To keep it consistent with "Increase" , but let me know if you want to keep it as "Reduce" if it makes more sense to you
- `!setname 0x100d X-Saber`
Character
- `!setname 0x94 Cybernetic`
Order
#
**The following strings are also missing , but i dont know if Salvation has included them yet in their source code :**
`!system 66`
`!system 569`
`!system 570`