### PR TITLE
add missing strings

### DIFF
--- a/http/strings/en.conf
+++ b/http/strings/en.conf
@@ -34,6 +34,7 @@
 !system 63 Tails effect
 !system 64 Gemini
 !System 65 Use Effect
+!system 66 持续公开
 !system 70 Monster Card
 !system 71 Spell Card
 !system 72 Trap Card
@@ -112,6 +113,8 @@
 !system 566 Select a card to activate
 !system 567 Declare a Level/Rank
 !system 568 Select a card to activate the effect
+!system 569 Select a Zone to play the card
+!system 570 Select a Zone to become unusable
 !system 1000 Deck
 !system 1001 Hand
 !system 1002 Monster Zone


### PR DESCRIPTION
I copied the invisible character between the words "Normal" and "Summon" in `!system 1 Normal Summon` , so it shouldnt cut off in Salvation :

- `!system 66 持续公开`
Since we dont know what its for yet and should it show up as that Chinese string in Ygopro , then we will know what its for and how to translate it
Google Translate says its "Continued public" , so i assume its used in situations where you want to continue to keep cards revealed for whatever reason..

- `!system 569 Select a Zone to play the card`
- `!system 570 Select a Zone to become unusable`
https://github.com/SalvationDevelopment/YGOPro-Salvation-Server/pull/308