### PR TITLE
Add SSL to back end forum validation

### DIFF
--- a/libs/forum-validator.js
+++ b/libs/forum-validator.js
@@ -33,7 +33,7 @@ function forumValidate(data, callback) {
     //        
     //    }
     process.nextTick(function () {
-        var url = 'http://forum.ygopro.us/log.php',
+        var url = 'https://forum.ygopro.us/log.php',
             post = {
                 ips_username: data.username,
                 ips_password: data.password
@@ -75,8 +75,8 @@ function forumValidate(data, callback) {
 module.exports = forumValidate;
 
 var qs = require('querystring');
-var http = require('http');
-var server = http.createServer(function (request, response) {
+var https = require('https');
+var server = https.createServer(function (request, response) {
     response.writeHead(200, {
         "Content-Type": "text/json"
     });


### PR DESCRIPTION
I don't think you can guarantee that the post request won't be sent outside the server itself.

Commit message:
Add SSL to back end forum validation

I know it's sent over wss, but then you're resending it over http.
Not tested, but I don't see why it wouldn't work.
If not, I'm still glad I brought it to your attention.